### PR TITLE
38 ingest portland ridership data into database

### DIFF
--- a/app/scripts/portland_extract.py
+++ b/app/scripts/portland_extract.py
@@ -1,0 +1,178 @@
+"""
+OBJECTIVE: Import and Format Portland Ridership data
+AUTHOR: Jimena Salinas
+DATE: 04/30/2024
+
+SOURCES: the data sets were obtained by a direct request to the 
+TriMet Public Records department. This is the link to the form
+to request data sets for Tri Met: 
+https://trimet.org/publicrecords/recordsrequest.htm
+The  Receipt ID for this Public Records Request is PRR 2024-254.
+
+VARIABLES:
+    - station_id: (str) combines the city "Portland" with a given stop_id
+    - date: (datetime) represents a day in the format yyyy-mm-dd, only includes
+    values for 2023
+    - ridership: (int) represents the average number of bus and light rail Tri Met
+    riders. The riders value was originally provided as an average by season 
+    and day type (Saturday, Sunday, and Weekday). In order to fit the data model
+    for the project which is at the datetime level, the data has been mapped to dates in 2023.
+"""
+
+import pandas as pd
+from typing import Dict, Tuple
+
+
+folder_path = ".../CloudStorage/Box-Box/Route Rangers/Transit dataset exploration/Portland Ridership Data/portland_ridership/"
+
+
+file_names = {
+    "spring_sat": "2023 spring_saturday.xlsx",
+    "spring_weekday": "2023 spring_weekday.xlsx",
+    "spring_sunday": "2023 spring_sunday.xlsx",
+    "summer_sat": "2023 summer_saturday.xlsx",
+    "summer_weekday": "2023 summer_weekday.xlsx",
+    "summer_sunday": "2023 summer_sunday.xlsx",
+    "fall_sat": "2023 fall_saturday.xlsx",
+    "fall_weekday": "2023 fall_weekday.xlsx",
+    "fall_sunday": "2023 fall_sunday.xlsx",
+    "winter_sat": "2023 winter_saturday.xlsx",
+    "winter_weekday": "2023 winter_weekday.xlsx",
+    "winter_sunday": "2023 winter_sunday.xlsx",
+}
+
+
+# date ranges for 2023
+start_date = "2023-01-01"
+end_date = "2023-12-31"
+
+# data ranges for each season in 2023
+# this will be used to change the level of the data from aggreate at the
+# date type level into daily level (to match our data model)
+season_ranges = {
+    "Spring": (pd.to_datetime("2023-03-19"), pd.to_datetime("2023-06-20")),
+    "Summer": (pd.to_datetime("2023-06-20"), pd.to_datetime("2023-09-22")),
+    "Fall": (pd.to_datetime("2023-09-22"), pd.to_datetime("2023-12-21")),
+    "Winter": (pd.to_datetime("2023-12-21"), pd.to_datetime("2024-03-19")),
+}
+
+
+def load_data(file_path: str) -> pd.DataFrame:
+    """
+    reads and individual Excel file and returns an error
+    if the file path does not exist
+    """
+    try:
+        return pd.read_excel(file_path)
+    except FileNotFoundError:
+        print("File not found:", file_path)
+    except Exception as e:
+        print("An error occurred while loading data:", e)
+
+
+def load_ridership_datasets(file_names: Dict[str, str]) -> Dict[str, pd.DataFrame]:
+    """
+    Takes a dictionary in the form key: season_day type
+    and value: file name, loads the corresponding ridership
+    data and creates a column with the corresponding
+    season value and day type (Saturday, Weekday, or Sunday),
+    and returns a dictionary with a key (season_day) and value
+    (the corresponding dataframe).
+    """
+    data_frames = {}
+    for key, value in file_names.items():
+        df = load_data(folder_path + value)
+        # get season from filename
+        if "spring" in value:
+            df["season"] = "Spring"
+        elif "summer" in value:
+            df["season"] = "Summer"
+        elif "fall" in value:
+            df["season"] = "Fall"
+        elif "winter" in value:
+            df["season"] = "Winter"
+
+        # get day_type from filename
+        if "sat" in value:
+            df["day_type"] = "Saturday"
+        elif "weekday" in value:
+            df["day_type"] = "Weekday"
+        elif "sunday" in value:
+            df["day_type"] = "Sunday"
+        data_frames[key] = df
+    return data_frames
+
+
+def format_data(all_rider_data: Dict[str, pd.DataFrame]) -> Dict[str, pd.DataFrame]:
+    """
+    standarize column formats and keep the relevant
+    data fields needed to match our data model, or
+    merge the data at the datetime level
+    """
+    for key, df in all_rider_data.items():
+        df.columns = df.columns.str.lower().str.replace(" ", "_")
+        all_rider_data[key] = df[["location_id", "ons", "day_type", "season"]]
+    return all_rider_data
+
+
+def create_calendar_df(
+    start_date: str, end_date: str, season_ranges: Dict[str, Tuple[str, str]]
+) -> pd.DataFrame:
+    """
+    Create a dataframe with datetime values as well as
+    the corresponding season and day type associated with
+    each datetime, return a dataframe
+    """
+    calendar_dates = pd.date_range(start=start_date, end=end_date, freq="D")
+    calendar_df = pd.DataFrame(calendar_dates, columns=["date"])
+    calendar_df["day_type"] = calendar_df["date"].dt.day_name()
+    calendar_df["day_type"] = (
+        calendar_df["day_type"]
+        .map({"Saturday": "Saturday", "Sunday": "Sunday"})
+        .fillna("Weekday")
+    )
+    calendar_df["season"] = "Spring"
+
+    # label seasons based on date ranges
+    for season, (season_start, season_end) in season_ranges.items():
+        calendar_df.loc[
+            (calendar_df["date"] >= season_start) & (calendar_df["date"] < season_end),
+            "season",
+        ] = season
+
+    return calendar_df
+
+
+def merge_data(all_rider_data: pd.DataFrame, calendar_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Combines two dataframes by day type and season value,
+    returns a dataframe with the columns from both data frames
+    """
+    merged_data = pd.merge(
+        all_rider_data, calendar_df, on=["day_type", "season"], how="left"
+    )
+    return merged_data.sort_values(by=["date", "day_type", "season"], ascending=True)
+
+
+def export_to_json(sorted_data: pd.DataFrame, output_file: str) -> None:
+    sorted_data.to_json(output_file, orient="records")
+
+
+def main() -> None:
+    all_rider_data = load_ridership_datasets(file_names)
+    formatted_data = format_data(all_rider_data)
+    all_data = pd.concat(formatted_data.values(), ignore_index=True)
+
+    calendar_df = create_calendar_df(start_date, end_date, season_ranges)
+    merged_data = merge_data(all_data, calendar_df)
+    merged_data.rename(columns={"ons": "ridership"}, inplace=True)
+    merged_data["date"] = pd.to_datetime(merged_data["date"])
+    merged_data["station_id"] = merged_data["location_id"]
+    output_file = folder_path + "Portland_ridership.json"
+    export_to_json(
+        merged_data.reindex(columns=["date", "ridership", "station_id"]), output_file
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/app/scripts/portland_ingest.py
+++ b/app/scripts/portland_ingest.py
@@ -46,7 +46,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "geodjango.settings")
 
 django.setup()
 
-
 from route_rangers_api.models import TransitStation, RidershipStation
 
 

--- a/app/scripts/portland_ingest.py
+++ b/app/scripts/portland_ingest.py
@@ -1,0 +1,20 @@
+"""
+OBJECTIVE: Ingest Portland Ridership Data into our Database
+AUTHOR: Jimena Salinas
+DATE: 05/06/2024
+
+SOURCES: the data sets were obtained by a direct request to the 
+TriMet Public Records department. This is the link to the form
+to request data sets for Tri Met: 
+https://trimet.org/publicrecords/recordsrequest.htm
+The  Receipt ID for this Public Records Request is PRR 2024-254.
+
+VARIABLES:
+    - station_id: (str) combines the city "Portland" with a given stop_id
+    - date: (datetime) represents a day in the format yyyy-mm-dd, only includes
+    values for 2023
+    - ridership: (int) represents the average number of bus and light rail Tri Met
+    riders. The riders value was originally provided as an average by season 
+    and day type (Saturday, Sunday, and Weekday). In order to fit the data model
+    for the project which is at the datetime level, the data has been mapped to dates in 2023.
+"""

--- a/app/scripts/portland_ingest.py
+++ b/app/scripts/portland_ingest.py
@@ -32,6 +32,11 @@ from datetime import datetime
 import pytz
 from typing import List, Dict, Any
 from django.db.utils import IntegrityError
+from dotenv import load_dotenv
+
+load_dotenv()
+
+json_file_path = os.getenv("JSON_FILE_PATH")
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.abspath(os.path.join(current_dir, ".."))
@@ -99,14 +104,14 @@ def ingest_pdx_ridership_data(
                         station_id=foreign_key,
                     )
 
-                    print(
-                        f"Ingesting ridership data for station {record['station_id']}..."
-                    )
+                    if foreign_key % 10 == 0:
+                        print(f"Ingesting ridership data for key {foreign_key}...")
+                        # print info every 10 records
 
                     ridership_obj.save()
                 else:
                     print(
-                        f"Skipping ingestion for station {record['station_id']}, foreign key not found in TransitStation"
+                        f"Skipping ingestion for key {foreign_key}, foreign key not found in TransitStation"
                     )
 
         except TransitStation.DoesNotExist:
@@ -125,20 +130,13 @@ def ingest_pdx_ridership_data(
 
     print("Ingestion complete")
 
-    # Print the station IDs that didn't match
-    if stations_not_matched:
-        print("The following station IDs did not match any TransitStation:")
-        print(", ".join(stations_not_matched))
-
 
 def run():
     """
     Ingest PDX ridership data into Django db
     """
-    start_date = datetime(2023, 5, 9)
-    end_date = datetime(2023, 5, 31)
-    json_file_path = "/Users/jimenasalinas/Library/CloudStorage/Box-Box/Route Rangers/Transit dataset exploration/Portland Ridership Data/portland_ridership/Portland_ridership.json"
-    transit_station_ids = get_transit_station_ids_pdx()
+    start_date = datetime(2023, 7, 2)
+    end_date = datetime(2023, 7, 31)
     ingest_pdx_ridership_data(json_file_path, start_date, end_date)
 
 

--- a/app/scripts/portland_ingest.py
+++ b/app/scripts/portland_ingest.py
@@ -86,7 +86,6 @@ def ingest_pdx_ridership_data(
     """
     stations_not_matched = []
 
-    # RidershipStation.objects.all().delete()
     formatted_data = format_input_ridership_data(json_file_path, start_date, end_date)
 
     for record in formatted_data:

--- a/app/scripts/portland_ingest.py
+++ b/app/scripts/portland_ingest.py
@@ -18,3 +18,64 @@ VARIABLES:
     and day type (Saturday, Sunday, and Weekday). In order to fit the data model
     for the project which is at the datetime level, the data has been mapped to dates in 2023.
 """
+
+import json
+import sys
+import os
+from requests.models import Response
+import django
+import datetime
+import pytz
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.abspath(os.path.join(current_dir, ".."))
+sys.path.append(parent_dir)
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "geodjango.settings")
+
+django.setup()
+
+
+from route_rangers_api.models import TransitStation, RidershipStation
+
+
+def ingest_pdx_ridership_data(json_file_path: str) -> None:
+    """
+    Ingest portland ridership data from extracted JSON file
+    into Django database
+    """
+    with open(json_file_path, "r") as file:
+        data = json.load(file)
+
+    for record in data:
+        # Get the id from TransitStation using station_id + city = 'PDX'
+        foreign_key = TransitStation.objects.get(
+            station_id=record["station_id"], city="PDX"
+        ).id
+
+        print(f"ingesting ridership data for station {record['station_id']}...")
+        # For each row, create a RidershipStation object
+        timestamp_seconds = int(record["date"]) / 1000
+        date_obj = datetime.datetime.fromtimestamp(timestamp_seconds)
+        # to match model
+
+        ridership_obj = RidershipStation.objects.create(
+            id=foreign_key,
+            date=date_obj,
+            ridership=record["ridership"],
+            station_id=record["station_id"],
+        )
+        print(ridership_obj)
+    print("Ingestion complete")
+
+
+def run():
+    """
+    Ingest PDX ridership data into Django db
+    """
+    json_file_path = "/Users/jimenasalinas/Library/CloudStorage/Box-Box/Route Rangers/Transit dataset exploration/Portland Ridership Data/portland_ridership/Portland_ridership.json"
+    ingest_pdx_ridership_data(json_file_path)
+
+
+if __name__ == "__main__":
+    run()

--- a/app/scripts/portland_ingest.py
+++ b/app/scripts/portland_ingest.py
@@ -150,7 +150,7 @@ def run():
     """
     start_date = datetime(2023, 3, 8)
     end_date = datetime(2023, 3, 8)
-    json_file_path = "/Users/jimenasalinas/Library/CloudStorage/Box-Box/Route Rangers/Transit dataset exploration/Portland Ridership Data/portland_ridership/Portland_ridership.json"
+    json_file_path = ".../CloudStorage/Box-Box/Route Rangers/Transit dataset exploration/Portland Ridership Data/portland_ridership/Portland_ridership.json"
     transit_station_ids = get_transit_station_ids_pdx()
     ingest_pdx_ridership_data(json_file_path, start_date, end_date, transit_station_ids)
 

--- a/app/scripts/portland_ingest.py
+++ b/app/scripts/portland_ingest.py
@@ -45,13 +45,6 @@ django.setup()
 from route_rangers_api.models import TransitStation, RidershipStation
 
 
-def get_transit_station_ids_pdx() -> list:
-    """
-    Get a list of all id values from the TransitStation table for PDX
-    """
-    return list(TransitStation.objects.filter(city="PDX").values_list("id", flat=True))
-
-
 def format_input_ridership_data(
     json_file_path: str, start_date: datetime.date, end_date: datetime.date
 ) -> List[Dict[str, Any]]:
@@ -75,10 +68,7 @@ def format_input_ridership_data(
 
 
 def ingest_pdx_ridership_data(
-    json_file_path: str,
-    start_date: datetime.date,
-    end_date: datetime.date,
-    list_of_db_ids: List,
+    json_file_path: str, start_date: datetime.date, end_date: datetime.date
 ) -> None:
     """
     Ingest portland ridership data from extracted JSON file
@@ -102,24 +92,22 @@ def ingest_pdx_ridership_data(
                 # date formatting to match model
 
                 if start_date <= date_obj <= end_date:
-                    # Check if foreign key exists in the list of TransitStation ids
-                    if foreign_key in list_of_db_ids:
 
-                        ridership_obj = RidershipStation.objects.create(
-                            date=date_obj,
-                            ridership=record["ridership"],
-                            station_id=foreign_key,
-                        )
+                    ridership_obj = RidershipStation.objects.create(
+                        date=date_obj,
+                        ridership=record["ridership"],
+                        station_id=foreign_key,
+                    )
 
-                        print(
-                            f"Ingesting ridership data for station {record['station_id']}..."
-                        )
+                    print(
+                        f"Ingesting ridership data for station {record['station_id']}..."
+                    )
 
-                        ridership_obj.save()
-                    else:
-                        print(
-                            f"Skipping ingestion for station {record['station_id']}, foreign key not found in TransitStation"
-                        )
+                    ridership_obj.save()
+                else:
+                    print(
+                        f"Skipping ingestion for station {record['station_id']}, foreign key not found in TransitStation"
+                    )
 
         except TransitStation.DoesNotExist:
             stations_not_matched.append(record["station_id"])
@@ -147,11 +135,11 @@ def run():
     """
     Ingest PDX ridership data into Django db
     """
-    start_date = datetime(2023, 3, 8)
-    end_date = datetime(2023, 3, 8)
-    json_file_path = ".../CloudStorage/Box-Box/Route Rangers/Transit dataset exploration/Portland Ridership Data/portland_ridership/Portland_ridership.json"
+    start_date = datetime(2023, 5, 9)
+    end_date = datetime(2023, 5, 31)
+    json_file_path = "/Users/jimenasalinas/Library/CloudStorage/Box-Box/Route Rangers/Transit dataset exploration/Portland Ridership Data/portland_ridership/Portland_ridership.json"
     transit_station_ids = get_transit_station_ids_pdx()
-    ingest_pdx_ridership_data(json_file_path, start_date, end_date, transit_station_ids)
+    ingest_pdx_ridership_data(json_file_path, start_date, end_date)
 
 
 if __name__ == "__main__":

--- a/app/scripts/portland_ingest.py
+++ b/app/scripts/portland_ingest.py
@@ -10,7 +10,9 @@ https://trimet.org/publicrecords/recordsrequest.htm
 The  Receipt ID for this Public Records Request is PRR 2024-254.
 
 VARIABLES:
-    - station_id: (str) combines the city "Portland" with a given stop_id
+    - ID (int): this ID is the foreign key from the TransitStations table,
+    it can be obtained using city = 'PDX' and station_id
+    - station_id: (str) a stop_id (GTFS)
     - date: (datetime) represents a day in the format yyyy-mm-dd, only includes
     values for 2023
     - ridership: (int) represents the average number of bus and light rail Tri Met
@@ -26,6 +28,8 @@ from requests.models import Response
 import django
 import datetime
 import pytz
+from typing import List
+from django.db.utils import IntegrityError
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 parent_dir = os.path.abspath(os.path.join(current_dir, ".."))
@@ -39,34 +43,90 @@ django.setup()
 from route_rangers_api.models import TransitStation, RidershipStation
 
 
-def ingest_pdx_ridership_data(json_file_path: str) -> None:
+def get_transit_station_ids() -> list:
+    """
+    Get a list of all id values from the TransitStation table
+    """
+    return list(TransitStation.objects.values_list("id", flat=True))
+
+
+def get_list_of_stations() -> list:
+    """
+    Get a list of all id values from the TransitStation table as strings
+    """
+    return [
+        str(station_id)
+        for station_id in TransitStation.objects.values_list("station_id", flat=True)
+    ]
+
+
+def ingest_pdx_ridership_data(
+    json_file_path: str, list_of_db_ids: List, list_of_stations: List
+) -> None:
     """
     Ingest portland ridership data from extracted JSON file
     into Django database
     """
+    stations_not_matched = []
+
+    RidershipStation.objects.all().delete()
     with open(json_file_path, "r") as file:
         data = json.load(file)
 
     for record in data:
-        # Get the id from TransitStation using station_id + city = 'PDX'
-        foreign_key = TransitStation.objects.get(
-            station_id=record["station_id"], city="PDX"
-        ).id
+        try:
+            # Get the id from TransitStation using station_id + city = 'PDX'
+            foreign_key = TransitStation.objects.get(
+                station_id=str(record["station_id"]), city="PDX"
+            ).id
 
-        print(f"ingesting ridership data for station {record['station_id']}...")
-        # For each row, create a RidershipStation object
-        timestamp_seconds = int(record["date"]) / 1000
-        date_obj = datetime.datetime.fromtimestamp(timestamp_seconds)
-        # to match model
+            station_id = str(record["station_id"])
 
-        ridership_obj = RidershipStation.objects.create(
-            id=foreign_key,
-            date=date_obj,
-            ridership=record["ridership"],
-            station_id=record["station_id"],
-        )
-        print(ridership_obj)
+            # print(f"FOREIGN_key '{station_id}', {foreign_key}")
+
+            # Check if foreign key exists in the list of TransitStation ids
+            if (foreign_key in list_of_db_ids) and (station_id in list_of_stations):
+
+                print(f"Ingesting ridership data for station {record['station_id']}...")
+
+                #     # For each row, create a RidershipStation object
+                timestamp_seconds = int(record["date"]) / 1000
+                date_obj = datetime.datetime.fromtimestamp(timestamp_seconds)
+                # date formatting to match model
+
+                ridership_obj = RidershipStation.objects.create(
+                    id=foreign_key,
+                    date=date_obj,
+                    ridership=record["ridership"],
+                    station_id=station_id,
+                )
+                print(ridership_obj)
+                ridership_obj.save()
+            else:
+                print(
+                    f"Skipping ingestion for station {record['station_id']}, foreign key not found in TransitStation."
+                )
+
+        except TransitStation.DoesNotExist:
+            stations_not_matched.append(record["station_id"])
+            print(
+                f"Skipping ingestion for station {record['station_id']}, no matching TransitStation found."
+            )
+            continue
+
+        except IntegrityError as e:
+            # foreign key db rule violation
+            print(
+                f"Skipping ingestion for station {record['station_id']} due to foreign key constraint violation"
+            )
+            continue
+
     print("Ingestion complete")
+
+    # Print the station IDs that didn't match
+    if stations_not_matched:
+        print("The following station IDs did not match any TransitStation:")
+        print(", ".join(stations_not_matched))
 
 
 def run():
@@ -74,7 +134,9 @@ def run():
     Ingest PDX ridership data into Django db
     """
     json_file_path = "/Users/jimenasalinas/Library/CloudStorage/Box-Box/Route Rangers/Transit dataset exploration/Portland Ridership Data/portland_ridership/Portland_ridership.json"
-    ingest_pdx_ridership_data(json_file_path)
+    transit_station_ids = get_transit_station_ids()
+    list_of_stations = get_list_of_stations()
+    ingest_pdx_ridership_data(json_file_path, transit_station_ids, list_of_stations)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adding script to ingest Portland Ridership data. The script takes the data extracted from the provided TriMet files (JSON format), formats the dates to match model, and then ingests the records into the database. I tried bulk import, but I didn't see a big improvement in speed and there was an issue where Django doesn't support automatically creating incremental ids when using bulk import, so the solution of specifying from which ID number to start felt a bit clunky. Filtering out my JSON file by a subset of dates first did help with the ingestion. 

- I kept my extraction code separate so we could still use Pytest for that script.
- I tried adding duplicate date + id records to the db and the error "Skipping ingestion for station {record['station_id']} due to foreign key constraint violation" seems to catch these instances.
- It would still be good to add some tests once we have the pytest django test db figured out.