### PR TITLE
Add color-coded routes and extremely basic route and station tooltips to map

### DIFF
--- a/app/route_rangers_api/static/map.js
+++ b/app/route_rangers_api/static/map.js
@@ -24,6 +24,8 @@ export function initializeMap(coordinates, stations, iconUrl, routes) {
   for (var i = 0; i < stations.length; i++) {
     var station = stations[i];
     var marker = L.marker([station[0], station[1]], { icon: smallIcon });
+    marker.bindTooltip(station[2]);
+    console.log(station[2]);
     markers.addLayer(marker);
   };
 

--- a/app/route_rangers_api/static/map.js
+++ b/app/route_rangers_api/static/map.js
@@ -36,7 +36,11 @@ export function initializeMap(coordinates, stations, iconUrl, routes) {
 
   L.geoJSON(routes, {
     style: function (feature) {
-      return { color: '#' + feature.properties.color, weight: 3 };
+      return {
+        color: '#' + feature.properties.color,
+        weight: 3,
+        "opacity": .7
+      };
     },
     onEachFeature: function (feature, layer) {
       layer.bindPopup(feature.properties.route_name);

--- a/app/route_rangers_api/static/map.js
+++ b/app/route_rangers_api/static/map.js
@@ -1,11 +1,11 @@
-export function initializeMap(coordinates, stations, iconUrl) {
+export function initializeMap(coordinates, stations, iconUrl, routes) {
   // Initialize the map at center of city
   var map = L.map('map').setView(coordinates, 13);
 
   // Add a tile layer
   L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
-    attribution:
-      'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>',
+    // attribution:
+    //   'Map data (c) <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, (c) <a href="https://carto.com/attribution">CARTO</a>',
     subdomains: 'abcd',
     maxZoom: 19,
   }).addTo(map);
@@ -13,17 +13,32 @@ export function initializeMap(coordinates, stations, iconUrl) {
   // Custom icon for smaller markers
   var smallIcon = L.icon({
     iconUrl: iconUrl, // URL to a smaller icon image
-    iconSize: [15, 15], 
+    iconSize: [15, 15],
     iconAnchor: [6, 6],
   });
 
-  var markers = L.markerClusterGroup();
+  var markers = L.markerClusterGroup({
+    disableClusteringAtZoom: 16
+  });
 
   for (var i = 0; i < stations.length; i++) {
     var station = stations[i];
-    var marker = L.marker([station[0], station[1]],{icon: smallIcon});
+    var marker = L.marker([station[0], station[1]], { icon: smallIcon });
     markers.addLayer(marker);
   };
 
   map.addLayer(markers);
+
+
+  // Add routes layer
+
+  L.geoJSON(routes, {
+    style: function (feature) {
+      return { color: '#' + feature.properties.color, weight: 3 };
+    },
+    onEachFeature: function (feature, layer) {
+      layer.bindPopup(feature.properties.route_name);
+    }
+  }).addTo(map);
+
 };

--- a/app/route_rangers_api/templates/dashboard.html
+++ b/app/route_rangers_api/templates/dashboard.html
@@ -37,7 +37,7 @@
   <script type="module">
     import { initializeMap } from "{% static 'map.js' %}";
     var coordinates = {{ coordinates }};
-    var stations = {{ stations }};
+    var stations = {{ stations | safe }};
     var iconUrl = "{% static 'images/map_pin.png' %}";
     var routes = {{ routes | safe}};
     // "safe" parameter needed to deal with escaped quotation marks in GeoJSON

--- a/app/route_rangers_api/templates/dashboard.html
+++ b/app/route_rangers_api/templates/dashboard.html
@@ -39,7 +39,9 @@
     var coordinates = {{ coordinates }};
     var stations = {{ stations }};
     var iconUrl = "{% static 'images/map_pin.png' %}";
-    initializeMap(coordinates, stations, iconUrl);
+    var routes = {{ routes | safe}};
+    // "safe" parameter needed to deal with escaped quotation marks in GeoJSON
+    initializeMap(coordinates, stations, iconUrl, routes);
   </script>
 </div>
 

--- a/app/route_rangers_api/views.py
+++ b/app/route_rangers_api/views.py
@@ -50,7 +50,12 @@ def dashboard(request, city: str):
     stations = TransitStation.objects.values().filter(
         city=CITY_CONTEXT[city]["DB_Name"]
     )
-    lst_coords = [[point["location"].x, point["location"].y] for point in stations]
+    # print(stations)
+    lst_coords = [
+        [point["location"].x, point["location"].y, point["station_name"]]
+        for point in stations
+    ]
+    print(lst_coords)
 
     context = {
         "City": CITY_CONTEXT[city]["CityName"],

--- a/app/route_rangers_api/views.py
+++ b/app/route_rangers_api/views.py
@@ -2,7 +2,7 @@ from django.db.models import F
 from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponse, HttpResponseRedirect
 from django.template import loader
-from django.http import Http404
+from django.http import Http404, JsonResponse
 from django.urls import reverse
 from django.views import generic
 from django.utils import timezone
@@ -10,6 +10,8 @@ from django.core.serializers import serialize
 
 from app.route_rangers_api.utils.city_mapping import CITY_CONTEXT
 from route_rangers_api.models import TransitRoute, TransitStation
+
+import json
 
 
 def home(request):
@@ -31,8 +33,17 @@ def dashboard(request, city: str):
     # get commute
 
     # get paths
-    routes = TransitRoute.objects.filter(city="CHI").values(
-        "geo_representation", "route_name", "color"
+    routes = TransitRoute.objects.filter(city=CITY_CONTEXT[city]["DB_Name"])  # .values(
+    # MultiLineString needs to be serialized into a GeoJson object for Leaflet to
+    # work with it.
+    # to serialize into GeoJson, need to get out entire Django model object, not just
+    # the .values("geo_representation", "route_name", "color")
+    # with .values() you get "AttributeError: 'dict' has no component 'meta'"
+    routes_json = serialize(
+        "geojson",
+        routes,
+        geometry_field="geo_representation",
+        fields=("route_name", "color"),
     )
 
     # stations
@@ -53,6 +64,7 @@ def dashboard(request, city: str):
         "feedback_class": "cs-li-link",
         "coordinates": CITY_CONTEXT[city]["Coordinates"],
         "stations": lst_coords,
+        "routes": routes_json,
     }
     return render(request, "dashboard.html", context)
 

--- a/app/route_rangers_api/views.py
+++ b/app/route_rangers_api/views.py
@@ -50,12 +50,11 @@ def dashboard(request, city: str):
     stations = TransitStation.objects.values().filter(
         city=CITY_CONTEXT[city]["DB_Name"]
     )
-    # print(stations)
+
     lst_coords = [
         [point["location"].x, point["location"].y, point["station_name"]]
         for point in stations
     ]
-    print(lst_coords)
 
     context = {
         "City": CITY_CONTEXT[city]["CityName"],


### PR DESCRIPTION
Resolves #84 . Gets the basics of #89 (which still need to be built out to include route information, ridership data if available, etc.)

Screenshots:
As of now, line names display when _clicking on_ a transit line, and station names display when _hovering over_ a station icon (at low enough zoom level, once cluster has fully declustered). Note that even for bus lines typically referred to by a number (as in Chicago's CTA) it displays the text name, not the number, of the route:
![Screen Shot 2024-05-14 at 12 47 06 AM](https://github.com/uchicago-capp-30320/RouteRangers/assets/111554739/a68f58a2-8852-4ee5-bf4c-d161b0c050ef)
.
The New York colors are wild!! We should look into whether these are substantively meaningful for buses and, if not, consider hard-coding over bus lines to be a more neutral color distinguished from the subway lines:
![Screen Shot 2024-05-14 at 12 45 46 AM](https://github.com/uchicago-capp-30320/RouteRangers/assets/111554739/27d65f10-b186-41f9-a768-46788033617f)
.
We're having some display issues with Metra, which is not showing at all. (The other notable commuter rail line in our trial cities, the WES Commuter Rail, is displaying properly without issue on the Portland map.) TODO: Investigate what's going on (hypotheses: extra whitespace in the color strings, column names are slightly different so color column isn't read in)
![Screen Shot 2024-05-14 at 12 44 51 AM](https://github.com/uchicago-capp-30320/RouteRangers/assets/111554739/ab728531-b70e-4085-aa8a-e5ca934f0c32)

Also still TODO: figure out how to display overlapping lines side-by-side, which isn't implemented yet.