### PR TITLE
Add layer toggle to map

### DIFF
--- a/app/route_rangers_api/static/map.js
+++ b/app/route_rangers_api/static/map.js
@@ -1,14 +1,15 @@
 export function initializeMap(coordinates, stations, iconUrl, routes) {
-  // Initialize the map at center of city
-  var map = L.map('map').setView(coordinates, 13);
 
   // Add a tile layer
-  L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+  var tileLayer = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
     // attribution:
     //   'Map data (c) <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, (c) <a href="https://carto.com/attribution">CARTO</a>',
     subdomains: 'abcd',
     maxZoom: 19,
-  }).addTo(map);
+  });
+
+  // Initialize the map at center of city
+  var map = L.map('map', { layers: [tileLayer] }).setView(coordinates, 13);
 
   // Custom icon for smaller markers
   var smallIcon = L.icon({
@@ -34,7 +35,7 @@ export function initializeMap(coordinates, stations, iconUrl, routes) {
 
   // Add routes layer
 
-  L.geoJSON(routes, {
+  var routesJSON = L.geoJSON(routes, {
     style: function (feature) {
       return {
         color: '#' + feature.properties.color,
@@ -45,6 +46,19 @@ export function initializeMap(coordinates, stations, iconUrl, routes) {
     onEachFeature: function (feature, layer) {
       layer.bindPopup(feature.properties.route_name);
     }
-  }).addTo(map);
+  });
+
+  map.addLayer(routesJSON);
+
+  var baseMaps = {
+    "base": tileLayer
+  }
+
+  var overlayMaps = {
+    "Stations": markers,
+    "Routes": routesJSON
+  };
+
+  var layerControl = L.control.layers(baseMaps, overlayMaps).addTo(map);
 
 };

--- a/app/route_rangers_api/utils/city_mapping.py
+++ b/app/route_rangers_api/utils/city_mapping.py
@@ -1,4 +1,3 @@
-
 CITIES_CHOICES = {"CHI": "Chicago", "NYC": "New York", "PDX": "Portland"}
 
 # keying by "nospace" naming scheme b/c that is how things will be passed via the url
@@ -12,7 +11,7 @@ CITY_CONTEXT = {
         "DB_Name": "CHI",
         "csv": "https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/barplot_change_data.csv",
         "lineplot": "https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/data_connectedscatter.csv",
-        'geojsonfilepath': 'ChicagoCensus.geojson'
+        "geojsonfilepath": "ChicagoCensus.geojson",
     },
     "NewYork": {
         "CityName": "New York",
@@ -21,7 +20,7 @@ CITY_CONTEXT = {
         "DB_Name": "NYC",
         "csv": "https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/barplot_change_data.csv",
         "lineplot": "https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/data_connectedscatter.csv",
-        'geojsonfilepath': "newyork.geojson"
+        "geojsonfilepath": "newyork.geojson",
     },
     "Portland": {
         "CityName": "Portland",
@@ -30,6 +29,6 @@ CITY_CONTEXT = {
         "DB_Name": "PDX",
         "csv": "https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/barplot_change_data.csv",
         "lineplot": "https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/data_connectedscatter.csv",
-        'geojsonfilepath': 'portland.geojson'
+        "geojsonfilepath": "portland.geojson",
     },
 }

--- a/app/route_rangers_api/views.py
+++ b/app/route_rangers_api/views.py
@@ -10,7 +10,6 @@ from django.core.serializers import serialize
 from django.templatetags.static import static
 
 
-
 from app.route_rangers_api.utils.city_mapping import CITY_CONTEXT
 from route_rangers_api.models import TransitRoute, TransitStation
 
@@ -58,7 +57,7 @@ def dashboard(request, city: str):
         [point["location"].x, point["location"].y, point["station_name"]]
         for point in stations
     ]
-    
+
     city_name = CITY_CONTEXT[city]["CityName"]
 
     context = {
@@ -76,8 +75,8 @@ def dashboard(request, city: str):
         "stations": lst_coords,
         "csv": CITY_CONTEXT[city]["csv"],
         "lineplot": CITY_CONTEXT[city]["lineplot"],
-        'geojsonfilepath': static(CITY_CONTEXT[city]['geojsonfilepath']),
-        "routes": routes_json
+        "geojsonfilepath": static(CITY_CONTEXT[city]["geojsonfilepath"]),
+        "routes": routes_json,
     }
     return render(request, "dashboard.html", context)
 


### PR DESCRIPTION
Following official Leaflet tutorial closely:
https://leafletjs.com/examples/layers-control/

Separate out commands to instantiate map layers from commands to add them to map.

Create a "control" object whose "overlayMaps" parameter determines which features can be toggled on or off.

For now, set all "stations" as one toggle-able feature, and all "routes" as another.

TODO: separate out different station/route layers based on mode of transit and/or line of interest. This would likely involve initializing distinct layers (e.g. busStations, railStations, busRoutes...) and then using conditional logic (perhaps relying on passing in the `route_type` GTFS number) to determine what goes where.

**Do _not_ delete this branch when merging**