### PR TITLE
Improve usability instructions on route draw screen of survey

### DIFF
--- a/app/route_rangers_api/templates/survey_map.html
+++ b/app/route_rangers_api/templates/survey_map.html
@@ -7,7 +7,7 @@
   <p class="inline">
     Please enter&nbsp;<strong>a trip</strong>&nbsp;you frequently take on transit, by bike, or by car.
   </p>
-  <ul>
+  <ul style="color:rgba(0, 0, 0, 0.6)">
     <li>Type in the the "Start" search bar and press Enter/Return to find or set a starting location. This will add a
       pin where
       the trip starts.</li>

--- a/app/route_rangers_api/templates/survey_map.html
+++ b/app/route_rangers_api/templates/survey_map.html
@@ -5,34 +5,50 @@
 <div class="headers">
   <h1>{{ City }} Rider Survey</h1>
   <p class="inline">
-    Please enter the trips you frequently take on transit, bike, or by car.
-    Click on the map to drop a start pin and then click to add a pin where the
-    trip ends. This feedback will be used to assess gaps in current transit
+    Please enter&nbsp;<strong>a trip</strong>&nbsp;you frequently take on transit, by bike, or by car.
+  </p>
+  <ul>
+    <li>Type in the the "Start" search bar and press Enter/Return to find or set a starting location. This will add a
+      pin where
+      the trip starts.</li>
+    <li>Type in the "End" search bar and press Enter/Return to find or set an ending location. This will add a pin where
+      the
+      trip ends.</li>
+    <li>The map will then find and show you route between your start and end points.
+      If it doesn't match your actual route, click and drag the route
+      until it looks right!</li>
+    <li><strong>Please click the "Save File" button <em>before</em> clicking "Next"! If you don't, your route
+        will not be saved!</strong></li>
+  </ul>
+  <p class="inline">This feedback will be used to assess gaps in current transit
     routes. We will ask you some follow-up questions to better understand
-    whether a new transit route would make this trip easier for you. Please
-    enter up to three routes.
+    whether a new transit route would make this trip easier for you. After that, you can enter a second or third route
+    if
+    you want.
   </p>
 </div>
 <style>
   .map {
-      position: absolute;
-      width: 100%;
-      height: 100%;
+    position: absolute;
+    width: 100%;
+    height: 100%;
   }
+
   .leaflet-routing-alternatives-container {
-      display: none;
+    display: none;
   }
+
   .export-button {
-      background: #edeeed;
-      padding: 5px;
-      cursor: pointer;
-      margin-left: auto;
-      width: 100%;
-      text-align: center;
-      font-weight: bold;
+    background: #edeeed;
+    padding: 5px;
+    cursor: pointer;
+    margin-left: auto;
+    width: 100%;
+    text-align: center;
+    font-weight: bold;
   }
 </style>
-{% block map %} 
+{% block map %}
 <div id="map" class="map"></div>
 
 <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet.js"></script>
@@ -47,7 +63,7 @@
 {% endblock %}
 {% block survey %}
 <form method="post">
-  {% csrf_token %} 
+  {% csrf_token %}
   {{ form }}
   <input type="hidden" id="lineStringInput" name="lineString">
   <div style="text-align: right">

--- a/app/route_rangers_api/templates/survey_map.html
+++ b/app/route_rangers_api/templates/survey_map.html
@@ -20,12 +20,11 @@
     <li><strong>Please click the "Save File" button <em>before</em> clicking "Next"! If you don't, your route
         will not be saved!</strong></li>
   </ul>
-  <p class="inline">This feedback will be used to assess gaps in current transit
-    routes. We will ask you some follow-up questions to better understand
-    whether a new transit route would make this trip easier for you. After that, you can enter a second or third route
-    if
-    you want.
-  </p>
+  <p class="inline">We will ask you some follow-up questions to better understand
+    whether a new transit route would make this trip easier for you. This feedback will be used to assess gaps in
+    current transit
+    routes.</p>
+  <p class="inline">After that, you can enter a second or third route if you want.</p>
 </div>
 <style>
   .map {


### PR DESCRIPTION
New instructions look like this:

<img width="932" alt="Screen Shot 2024-05-22 at 11 35 12 AM" src="https://github.com/uchicago-capp-30320/RouteRangers/assets/111554739/cdf76556-9cde-4e38-a4d6-bd47348640a2">
